### PR TITLE
test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
         "@nestjs/schematics": "^9.0.0",
-        "@nestjs/testing": "^9.0.0",
+        "@nestjs/testing": "^9.4.0",
         "@types/express": "^4.17.13",
         "@types/jest": "29.2.4",
         "@types/node": "18.11.18",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "start:dev": "npm run prebuild && NODE_ENV=dev nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "NODE_ENV=prod node dist/main",
-    "schema:drop": "ts-node ./node_modules/typeorm/cli.js schema:drop -d ./src/data-source.ts",
-    "schema:sync": "ts-node ./node_modules/typeorm/cli.js schema:sync -d ./src/data-source.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -45,7 +43,7 @@
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
-    "@nestjs/testing": "^9.0.0",
+    "@nestjs/testing": "^9.4.0",
     "@types/express": "^4.17.13",
     "@types/jest": "29.2.4",
     "@types/node": "18.11.18",

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { UsersModule } from 'src/users/users.module';
+import { UsersModule } from '../users/users.module';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import * as dotenv from 'dotenv';

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { UsersService } from 'src/users/users.service';
 import { LogInDto } from './dto/login.dto';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class AuthService {

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,19 +1,15 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { UserRepository } from 'src/users/users.repository';
-import { User } from 'src/users/entities/user.entity';
+import { UserRepository } from '../users/users.repository';
+import { User } from '../users/entities/user.entity';
 import * as dotenv from 'dotenv';
 
 dotenv.config({ path: './src/env/.env.dev' });
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(
-    @InjectRepository(UserRepository)
-    private userRepository: UserRepository,
-  ) {
+  constructor(private userRepository: UserRepository) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -23,9 +19,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload) {
     const { email, nickname } = payload;
-    const user: User = await this.userRepository.findOne({
-      where: { email, nickname },
-    });
+    const user: User = await this.userRepository.validateUser(email, nickname);
     if (!user) throw new UnauthorizedException();
     return user;
   }

--- a/src/users/dto/response-user.dto.ts
+++ b/src/users/dto/response-user.dto.ts
@@ -1,0 +1,11 @@
+import { User } from '../entities/user.entity';
+
+export class ResponseUserDto {
+  email: string;
+  nickname: string;
+
+  constructor(user: User) {
+    this.email = user.email;
+    this.nickname = user.nickname;
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -11,13 +11,13 @@ export class User {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column('varchar', { unique: true, nullable: false })
+  @Column('varchar', { unique: true })
   email: string;
 
-  @Column('varchar', { unique: false, nullable: false })
+  @Column('varchar')
   password: string;
 
-  @Column('varchar', { unique: true, nullable: false })
+  @Column('varchar', { unique: true })
   nickname: string;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -4,6 +4,7 @@ import { UsersService } from './users.service';
 
 describe('UsersController', () => {
   let controller: UsersController;
+  let service: UsersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,6 +13,19 @@ describe('UsersController', () => {
     }).compile();
 
     controller = module.get<UsersController>(UsersController);
+    service = module.get<UsersService>(UsersService);
+  });
+
+  describe('signup', () => {
+    it('signup controller', async () => {
+      const user = {
+        email: 'test@test.com',
+        nickname: 'test',
+        password: 'test',
+      };
+      const signedUser = await service.signUp(user);
+      expect(signedUser).toBe(201);
+    });
   });
 
   it('should be defined', () => {

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -5,13 +5,11 @@ import { User } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 
 @Injectable()
-export class UserRepository extends Repository<User> {
+export class UserRepository {
   constructor(
     @InjectRepository(User)
     private readonly repository: Repository<User>,
-  ) {
-    super(repository.target, repository.manager, repository.queryRunner);
-  }
+  ) {}
 
   async checkEmail(email: string): Promise<boolean> {
     const result = await this.repository.findOne({ where: { email } });
@@ -24,6 +22,14 @@ export class UserRepository extends Repository<User> {
   }
 
   async findEmail(email: string) {
-    return await this.repository.findOne({ where: { email } });
+    return await this.repository.findOneBy({ email });
+  }
+
+  async save(user) {
+    return await this.repository.save(user);
+  }
+
+  async validateUser(email, nickname) {
+    return await this.repository.findOne({ where: { email, nickname } });
   }
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,18 +1,19 @@
+import { boolean } from 'yargs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
+import { ResponseUserDto } from './dto/response-user.dto';
+import { UserRepository } from './users.repository';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let repository: UserRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [UsersService, UserRepository],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
-  });
-
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+    repository = module.get<UserRepository>(UserRepository);
   });
 });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,14 +1,12 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
-import { InjectRepository } from '@nestjs/typeorm';
 import { UserRepository } from './users.repository';
 import * as bcrypt from 'bcrypt';
+import { ResponseUserDto } from './dto/response-user.dto';
 
 @Injectable()
 export class UsersService {
-  constructor(
-    @InjectRepository(UserRepository) private usersRepository: UserRepository,
-  ) {}
+  constructor(private usersRepository: UserRepository) {}
 
   async signUp(body: CreateUserDto) {
     const { email, password, nickname } = body;
@@ -28,8 +26,7 @@ export class UsersService {
 
     await this.usersRepository.save(user);
 
-    // TODO: 패스워드는 반환 값에서 빼기
-    return user;
+    return new ResponseUserDto(user);
   }
 
   async findEmail(email: string) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -15,6 +15,31 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  describe('/users', () => {
+    it('/signup (POST)', () => {
+      return request(app.getHttpServer())
+        .post('/users/signup')
+        .send({
+          email: 'test3@gmail.com',
+          nickname: 'test3',
+          password: 'test3',
+        })
+        .expect(201);
+    });
+  });
+
+  describe('auth', () => {
+    it('/login (POST)', () => {
+      return request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email: 'test3@gmail.com',
+          password: 'test3',
+        })
+        .expect(201);
+    });
+  });
+
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')


### PR DESCRIPTION
- 유닛 테스트는 계속 종속성 주입 에러가 발생해서 하지 못 했습니다. 구글링을 주말 동안 계속 했는데도 해결책을 찾지 못 했습니다...
- 테스트 코드 너무 어렵네요...

## 구현사항
- 코치님의 3주차 피드백을 보고 코드 수정을 했습니다. (responseDto 생성, boolean 반환시 count 함수 사용, extends Repository 삭제)
- e2e 테스트 코드 작성 - 이것도 너무 간단하게 작성해서 테스트의 의미가 있을까 생각합니다...


## 질문사항
1. 저번 피드백에서 함수의 반환값을 dto로 만들라고 하셔서 패스워드를 뺀 채로 반환을 할 수 있게 구현을 했는데요. 코드를 짜다가 생각해보니 인터셉터도 함수의 반환값을 변경해주는 역할을 하니까 패스워드를 뺼 수 있지 않을까 해서 dto를 쓰지 않고 delete data.password 이렇게 해서 객체의 프로퍼티를 삭제했더니 동작은 에러없이 잘 되더라고요. 객체의 프로퍼티를 직접 삭제해주는 것보다 dto를 쓰는 방법이 더 깔끔하게 느껴지기는 하는데 코치님이 생각하시기에는 어떤 방법이 더 좋으신가요?

2. 그리고 회원가입시 요청 body에 email, nickname이랑 같이 password도 같이 나오는데 요청시에도 password가 안 나오게 해야할까요? 

